### PR TITLE
【Fixed】管理者のみ利用可能なリンクやボタンを一般ユーザには表示させないようにした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def set_user
+    @user = current_user
+  end
+
   protected
 
   def configure_permitted_parameters

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,9 @@
     <% if user_signed_in? %>
       <%= link_to "新規投稿", posts_path %>
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+        <% if current_user.admin? %>
+          <%= link_to '管理画面へ', rails_admin_path %>
+        <% end %>
     <% else %>
       <%= link_to "新規登録", new_user_registration_path %>
       <%= link_to "ログイン", new_user_session_path %>


### PR DESCRIPTION
- 管理者としてログインした場合、ヘッダーに管理画面へリダイレクトするリンクを表示するようにした